### PR TITLE
idToken exposed to Client

### DIFF
--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -45,13 +45,14 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 		}
 	}
     
+    /// Authenticated Identity and profile token; assigned when scoped with `openid` and `profile`.
     public var idToken: String? {
         get { return auth?.oauth?.idToken }
     }
 	
 	/// Settings to be applied to the Auth instance.
 	var authSettings: OAuth2JSON? {
-		didSet {
+        didSet {
 			didSetAuthSettings()
 		}
 	}

--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -44,6 +44,10 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 			}
 		}
 	}
+    
+    public var idToken: String? {
+        get { return auth?.oauth?.idToken }
+    }
 	
 	/// Settings to be applied to the Auth instance.
 	var authSettings: OAuth2JSON? {

--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -45,11 +45,11 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 		}
 	}
     
-    /// Authenticated Identity and profile token; assigned when scoped with `openid` and `profile`.
-    public var idToken: String? {
-        get { return auth?.oauth?.idToken }
-    }
-	
+	/// Authenticated Identity and profile token; assigned when scoped with `openid` and `profile`.
+	public var idToken: String? {
+		get { return auth?.oauth?.idToken }
+	}
+
 	/// Settings to be applied to the Auth instance.
 	var authSettings: OAuth2JSON? {
         didSet {

--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -52,7 +52,7 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 
 	/// Settings to be applied to the Auth instance.
 	var authSettings: OAuth2JSON? {
-        didSet {
+		didSet {
 			didSetAuthSettings()
 		}
 	}


### PR DESCRIPTION
This Pull Request makes `idToken` available to the smart `Client` through the `Server`. (`Client.Server.idToken`).

This would allow Clients to resolve user `profile` through the `IdToken` when using scopes like `openid profile`. 

More on IdToken use: [SMART-on-FHIR Documentation](http://docs.smarthealthit.org/authorization/scopes-and-launch-context/)