### PR TITLE
idToken exposed to Client for resolving User identity

### DIFF
--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -52,6 +52,11 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 		}
 	}
 	
+	/// Authenticated identity and profile token of end user; Assigned when scopes `openid` and `profile` are used.
+	public var idToken: String? {
+		get { return auth?.oauth?.idToken }
+	}
+	
 	var mustAbortAuthorization = false
 	
 	/// An optional NSURLSessionDelegate.

--- a/Sources/iOS/PatientList+iOS.swift
+++ b/Sources/iOS/PatientList+iOS.swift
@@ -27,7 +27,7 @@ open class PatientListViewController: UITableViewController {
 	}
 	
 	/// Block to execute when a patient has been selected.
-	var onPatientSelect: ((Patient?) -> Void)?
+	public var onPatientSelect: ((Patient?) -> Void)?
 	
 	var didSelectPatientFlag = false
 	


### PR DESCRIPTION
Clients would require a way to resolve logged in User identity (useful in Practitioner Launch Context).

This Pull request exposes `id_token` to the `Client` through `Server`
This would allow Clients to resolve authenticated user identity and its FHIR Resource

More: [SMART-on-FHIR Launch Context and Scopes](http://docs.smarthealthit.org/authorization/scopes-and-launch-context/)