### PR TITLE
Exposed public refreshToken property in Server

### DIFF
--- a/Sources/Client/Server.swift
+++ b/Sources/Client/Server.swift
@@ -57,6 +57,11 @@ open class Server: FHIROpenServer, OAuth2RequestPerformer {
 		get { return auth?.oauth?.idToken }
 	}
 	
+	/// The refresh token provided with the access token; Issuing a refresh token is optional at the discretion of the authorization server.
+    	public var refreshToken: String? {
+        	get { return auth?.oauth?.refreshToken }
+    	}
+	
 	var mustAbortAuthorization = false
 	
 	/// An optional NSURLSessionDelegate.


### PR DESCRIPTION
Exposed public refreshToken property so framework consumers can request additional tokens without requiring users to go through the sign in flow again.